### PR TITLE
Update metadata request: ASCDC-DQOT

### DIFF
--- a/monitoring_requests/ASCDC-DQOT.json
+++ b/monitoring_requests/ASCDC-DQOT.json
@@ -1,0 +1,84 @@
+{
+  "ASCDC-DQOT": {
+    "_id": "ASCDC-DQOT",
+    "identifier": "ASCDC-DQOT",
+    "title": "Database of Qing Official Titles (DQOT) test eteste",
+    "doi": "",
+    "license": "http://www.opendefinition.org/licenses/cc-zero",
+    "description": {
+      "en": "TESTES----Thfdsfdsfdse LOD dataset of ASCDC_Database of Qing Official Titles (DQOT) was created by the Academia Sinica Center for Digital Cultures (ASCDC) and based on the metadata from the online “Database of Qing Official Titles” (清代職官資料庫, https://newarchive.ihp.sinica.edu.tw/officerc/officerkm2?@@0.21081762485249556), which was established and maintained by the Institute of History and Philology, Academia Sinica, Taipei, Taiwan (ROC). The data includes titles of the official positions in the Qing dynasty (1644-1911) and their detailed information, which can serve as authority files or controlled vocabularies for official positions in the study of Chinese history. Containing 6,846 data records and 164,733 triples, the textual content within the LOD dataset is licensed under the Creative Commons Attribution (CC BY)."
+    },
+    "sparql": [
+      {
+        "access_url": "https://data.ascdc.tw/en/sparql.php",
+        "title": "Adsdsdsadasdasda",
+        "description": "Access to the SPARQL endpoint of ASCDC's LOD datasets for data retrieval (with template-based examples), downloads and further reuse."
+      }
+    ],
+    "full_download": [
+      {
+        "title": "ASCDC LODDatasets",
+        "download_url": "https://data.ascdc.tw/en/index.php",
+        "description": "Launched in 2018, ASCDC LODDatasets is an online portal platform for publishing LOD-based datasets, which are converted and provided by the ASCDC in Taiwan (R.O.C), with service for SPARQL queries and data downloads."
+      },
+      {
+        "title": "ASCDC LODDataset of Database of Qing Official Titles",
+        "download_url": "https://data.ascdc.tw/dataset/ASCDC-DQOT.ttl",
+        "description": "Full download of ASCDC LODDataset of Dataabase of Qing Official Titles in ttl format."
+      }
+    ],
+    "website": "https://data.ascdc.tw/en/data.php",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "Dr. Shu-Jiun Sophy Chen (Academia Sinica Center for Digital Cultures, Taiwan R.O.C.)cdsfsfsd",
+      "email": "sophy@gate.sinica.edu.tw"
+    },
+    "owner": {
+      "name": "",
+      "email": "luluyen1210@gmail.com"
+    },
+    "keywords": [
+      "ASCDC",
+      "Chinese History",
+      "History",
+      "Qing Dynasty",
+      "Qing Official Titles",
+      "Academia Sinica",
+      "Institute of History and Philology",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [
+      {
+        "title": "Example Resource: Prime Minister of the Imperial Cabinet / 內閣總理大臣",
+        "access_url": "https://data.ascdc.tw/OfficialPosition/DQOT/Central/NO000002819/01",
+        "description": "Resource contains the LOD-based data on the Chinese Official Title of the Prime Minister of the Imperial Cabinet/ 內閣總理大臣."
+      },
+      {
+        "title": "Example Resource: Governor-General of Sichuan Province / 四川總督",
+        "access_url": "https://data.ascdc.tw/OfficialPosition/DQOT/Provincial/NO000000141",
+        "description": "Resource contains the LOD-based data on the Chinese Official Title of the Governor-General of Sichuan Province/ 四川總督."
+      }
+    ],
+    "other_download": [
+      {
+        "title": "ASCDC LODDatasets - Downloads",
+        "access_url": "https://data.ascdc.tw/en/data.php",
+        "description": "Webpage of ASCDC LODDatasets for downloads of entire published LOD-based datasets."
+      }
+    ],
+    "namespace": "http://data.ascdc.tw/OfficialPosition/DQOT/",
+    "links": [
+      {
+        "_id": "bf667ffc-3082-53eb-0433-e191bbc167e6",
+        "target": "ASCDC - DNB",
+        "value": "13339"
+      }
+    ],
+    "time": "",
+    "triples": "8",
+    "category": "ch-tangible"
+  }
+}

--- a/monitoring_requests/cht.json
+++ b/monitoring_requests/cht.json
@@ -1,0 +1,75 @@
+{
+  "cht": {
+    "_id": "cht",
+    "identifier": "cht",
+    "title": "tetetwtrwtwCultural Heritage Thesaurus",
+    "doi": "",
+    "license": "http://www.opendefinition.org/licenses/cc-by",
+    "description": {
+      "en": "twtwetwrtrwtrConcepts that cover the cultural heritage field in the Netherlands."
+    },
+    "sparql": [
+      {
+        "access_url": "https://digitaalerfgoed.poolparty.biz/PoolParty/sparql/term/id/cht",
+        "title": "Cultuurhistorische Thesaurus SPARQL",
+        "description": ""
+      }
+    ],
+    "full_download": [
+      {
+        "title": "Cultuurhistorische Thesaurus",
+        "download_url": "https://data.cultureelerfgoed.nl/term/id/cht/export/term/id/cht.ttl",
+        "description": ""
+      }
+    ],
+    "website": "https://data.cultureelerfgoed.nl/",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "Joop Vanderheiden",
+      "email": "j.vanderheiden@cultureelerfgoed.nl"
+    },
+    "owner": {
+      "name": "",
+      "email": "jolietjakeblues64@gmail.com"
+    },
+    "keywords": [
+      "cultural heritage",
+      "archaeology",
+      "Architecture",
+      "Arthistory",
+      "historical buildings",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [],
+    "other_download": [],
+    "namespace": "https://data.cultureelerfgoed.nl/term/id/cht/tesstet",
+    "links": [
+      {
+        "_id": "1629e81a-918a-c6a7-2431-fdc7eaf21a78",
+        "target": "dbpedia-nl",
+        "value": "1996"
+      },
+      {
+        "_id": "2b8e35cd-e762-d31b-9c7d-2a046061d713",
+        "target": "dbpedia",
+        "value": "42"
+      },
+      {
+        "_id": "7ad360fd-2b8b-a56f-d0a6-0cefc7ee54a5",
+        "target": "getty-aat",
+        "value": "1683"
+      },
+      {
+        "_id": "0ffe9adc-0a63-2bb8-85e4-7399c1686f0e",
+        "target": "wikidata",
+        "value": "36"
+      }
+    ],
+    "time": "",
+    "triples": "43",
+    "category": "ch-tangible"
+  }
+}

--- a/monitoring_requests/princeton-library-findingaids.json
+++ b/monitoring_requests/princeton-library-findingaids.json
@@ -1,0 +1,62 @@
+{
+  "princeton-library-findingaids": {
+    "_id": "princeton-library-findingaids",
+    "identifier": "princeton-library-findingaids",
+    "title": "Princeton Library FindingAids",
+    "doi": "",
+    "license": "",
+    "description": {
+      "en": "Use this site to explore descriptions of our unique holdings at the Princeton University Libraries, which include manuscripts, archival collections, images, ephemera, and much more one-of-a-kind material."
+    },
+    "sparql": [],
+    "full_download": [],
+    "website": "http://findingaids.princeton.edu/",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "test",
+      "email": "huhhb@gmail.com"
+    },
+    "owner": {
+      "name": "",
+      "email": ""
+    },
+    "keywords": [
+      "LinkedDataCrawl2014",
+      "crawledLinkedDataCloud2014",
+      "format-dcterm",
+      "format-dctypes",
+      "format-foaf",
+      "format-open",
+      "format-rdf",
+      "format-time",
+      "format-vcard2006",
+      "lodcloud-diagram-2014-08-30",
+      "non-deref-vocab",
+      "provenance-metadata",
+      "publications",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [
+      {
+        "title": "",
+        "access_url": "http://findingaids.princeton.edu/collections/C0108/c02283",
+        "description": "Example resource"
+      }
+    ],
+    "other_download": [],
+    "namespace": "",
+    "links": [
+      {
+        "target": "lcsh",
+        "value": "9"
+      }
+    ],
+    "time": "",
+    "triples": 0,
+    "category": "ch-tangible",
+    "image": ""
+  }
+}

--- a/monitoring_requests/slod.json
+++ b/monitoring_requests/slod.json
@@ -2,11 +2,11 @@
   "slod": {
     "_id": "slod",
     "identifier": "slod",
-    "title": "Linked Stage Graph TEST TEST TEST",
+    "title": "Linked Stage Graph test teste",
     "doi": "",
     "license": "https://creativecommons.org/licenses/by/3.0/",
     "description": {
-      "en": "Linked Stage Graph is a Knowledge Graph using a dataset by the Archive of Baden-Wuerttemberg, Germany. It contains black and white photographs and metadata about the Stuttgart State Theaters from the 1890s to the 1940s. The original EAD-XML files were converted to RDF and named entities were extracted and linked to Wikidata and the German Authority Files (GND) cxzcxzczxczxvsberb565464hfdhdf"
+      "en": "Linked Stage Graph is a Knowledge Graph using a dataset by the Archive of Baden-Wuerttemberg, Germany. It contains black and white photographs and metadata about the Stuttgart State Theaters from the 1890s to the 1940s. The original EAD-XML files were converted to RDF and named entities were extracted and linked to Wikidata and the German Authority Files (GND). tetstet e"
     },
     "sparql": [
       {
@@ -16,7 +16,7 @@
       }
     ],
     "full_download": [],
-    "website": "http://slod.fiz-karlsruhe.de/noncsa31",
+    "website": "http://slod.fiz-karlsruhe.de/rewtnerjk43",
     "domain": "cultural-heritage",
     "contact_point": {
       "name": "Tabea Tietz",
@@ -53,7 +53,7 @@
       }
     ],
     "time": "",
-    "triples": "4035934068549645",
+    "triples": "4234325456345",
     "category": "ch-tangible"
   }
 }

--- a/monitoring_requests/slod.json
+++ b/monitoring_requests/slod.json
@@ -1,0 +1,59 @@
+{
+  "slod": {
+    "_id": "slod",
+    "identifier": "slod",
+    "title": "Linked Stage Graph TEST TEST TEST",
+    "doi": "",
+    "license": "https://creativecommons.org/licenses/by/3.0/",
+    "description": {
+      "en": "Linked Stage Graph is a Knowledge Graph using a dataset by the Archive of Baden-Wuerttemberg, Germany. It contains black and white photographs and metadata about the Stuttgart State Theaters from the 1890s to the 1940s. The original EAD-XML files were converted to RDF and named entities were extracted and linked to Wikidata and the German Authority Files (GND) cxzcxzczxczxvsberb565464hfdhdf"
+    },
+    "sparql": [
+      {
+        "access_url": "http://slod.fiz-karlsruhe.de/sparql",
+        "title": "Linked Stage Graph",
+        "description": ""
+      }
+    ],
+    "full_download": [],
+    "website": "http://slod.fiz-karlsruhe.de/noncsa31",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "Tabea Tietz",
+      "email": "tabea.tietz@fiz-karlsruhe.de"
+    },
+    "owner": {
+      "name": "",
+      "email": "tabea.tietz@googlemail.com"
+    },
+    "keywords": [
+      "theater",
+      "photographs",
+      "cultural heritage",
+      "archive",
+      "glam",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [],
+    "other_download": [],
+    "namespace": "http://slod.fiz-karlsruhe.de",
+    "links": [
+      {
+        "_id": "10969c98-6a3e-4125-c3b8-f1f3f65364fe",
+        "target": "wikidata",
+        "value": "1839"
+      },
+      {
+        "_id": "e3d93120-cd7a-d4cc-164b-d999d746b543",
+        "target": "dnb-gemeinsame-normdatei",
+        "value": "95"
+      }
+    ],
+    "time": "",
+    "triples": "4035934068549645",
+    "category": "ch-tangible"
+  }
+}

--- a/monitoring_requests/testeto342.json
+++ b/monitoring_requests/testeto342.json
@@ -1,0 +1,45 @@
+{
+  "testeto342": {
+    "_id": "",
+    "identifier": "testeto342",
+    "title": "fddfdnc434323",
+    "doi": "",
+    "license": "",
+    "description": {
+      "en": "fdsfjdn3o4jh23or"
+    },
+    "sparql": {
+      "0": {
+        "access_url": "",
+        "title": "",
+        "description": ""
+      },
+      "access_url": "http://fdsfdsf.com",
+      "title": "fsdfdsfasdf",
+      "description": "dsfdsfasfdsf"
+    },
+    "full_download": [],
+    "website": "http://localn.ci",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "test34",
+      "email": "test44@live.com"
+    },
+    "owner": {
+      "name": "",
+      "email": ""
+    },
+    "keywords": [
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [],
+    "other_download": [],
+    "namespace": "",
+    "links": [],
+    "time": "",
+    "triples": "2",
+    "category": "ch-tangible"
+  }
+}

--- a/monitoring_requests/testg43432.json
+++ b/monitoring_requests/testg43432.json
@@ -1,0 +1,65 @@
+{
+  "testg43432": {
+    "_id": "",
+    "identifier": "testg43432",
+    "title": "trst32fdf",
+    "doi": "",
+    "license": "",
+    "description": {
+      "en": "fdskvsdoi43242"
+    },
+    "sparql": [
+      {
+        "access_url": "https://test.tetst",
+        "title": "test",
+        "description": "test"
+      }
+    ],
+    "full_download": [
+      {
+        "title": "dsdas",
+        "download_url": "https://test",
+        "description": ""
+      },
+      {
+        "title": "sfdfdsf",
+        "download_url": "http://cnsudcnds.com",
+        "description": "dsfdsf"
+      }
+    ],
+    "website": "http://localn.ci",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "test klok",
+      "email": "test@gmail.com"
+    },
+    "owner": {
+      "name": "",
+      "email": ""
+    },
+    "keywords": [
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [
+      {
+        "title": "trfgdf",
+        "access_url": "http://exampl.comdf",
+        "description": "fsdfsdff"
+      }
+    ],
+    "other_download": [
+      {
+        "title": "fdsfsdf",
+        "access_url": "https://test.com",
+        "description": "fsdfsdfjk"
+      }
+    ],
+    "namespace": "",
+    "links": [],
+    "time": "",
+    "triples": 0,
+    "category": "ch-tangible"
+  }
+}

--- a/monitoring_requests/viaf.json
+++ b/monitoring_requests/viaf.json
@@ -1,0 +1,104 @@
+{
+  "viaf": {
+    "_id": "viaf",
+    "identifier": "viaf",
+    "title": "VIAF: The Virtual International Authority File",
+    "doi": "",
+    "license": "http://www.opendefinition.org/licenses/odc-by",
+    "description": {
+      "en": "VIAF (Virtual International Autority File) is an OCLC dataset and service -- built in cooperation with national libraries and other partners -- that virtually combines multiple LAM (Library Archives Museum) name authority files into a single name authority service. Put simply it is a large database of people and organizations that occur in library catalogs. TOPO GIGIO\n\n\nVIAF is a joint project of 20  national libraries, implemented and hosted by OCLC. The project's goal is to lower the cost and increase the utility of library authority files by matching and linking the authority files of national libraries, and then making that information available on the Web.\n\n### Openness\n\nThe data is released under Open Data Commons Attribution license. Attribution is requested as follows:\n\n> Adherence to ODC Attribution instructions for the correct assertion of attribution is encouraged. The preferred form of attribution for VIAF is:\n>\n> \"This [title of report or article or dataset] contains information from VIAF (Virtual International Authority File) which is made available under the ODC Attribution License.\"\n> \n> Special cases: In circumstances where providing the full attribution statement above is not technically feasible, the use of canonical VIAF URIs is adequate to satisfy Section 4.3 of the ODC Attribution License.\n\n#### Older information preserved for archival purposes\n\nOCLC is currently in discussion with partners about how to license material. [Message from Thom Hickey, OCLC Chief Scientist](http://groups.google.com/group/nyt_linked_open_data/browse_thread/thread/46ea00276e3d5a2e#) on public Google Groups mailing list in January 2010 states:\n\n> VIAF is a joint project with the contributing institutions and OCLC doesn?t claim any rights to the data beyond what the group has.  Unfortunately the group as a whole has problems coming up with a statement of exactly what is permitted.  In lieu of that, our position is that the data on the site is freely available for use through the APIs, although if someone wants a copy of the whole thing they would have to apply to the VIAF consortium (they could do that through me or Barbara Tillett at LC).  Along those same lines, if someone is going to have substantial activity against VIAF (multiple queries/second) we?d like to know about it ahead of time. \n\n> Over the next few months we will be working on a better statement of what?s permitted, but our intention is to make the data as freely available as possible (even to the NYT). \n\n\nFurther update from Thom Hickey:\n(http://outgoing.typepad.com/outgoing/2011/03/use-of-viaf.html)\n\n> I responded to a recent blog post on LibraryThing which mentioned restrictions on the use of VIAF and its relationship to the LC authority file.\n\n> In fact, VIAF is open for use by anyone.  Here's what I said about the use of VIAF:\n\n> VIAF is a project led by LC, the French and German national libraries and OCLC. There are no restrictions on its use. Dumps of the complete file are available, but need the approval of the project leaders.\n\n> VIAF is not designed to replace the LC/NACO authority file, but rather is built from it and a number of similar files.\n\n> I hope that is clear.  We really do want people to use VIAF!\n\nGood news, but no explicit license or complete dumps freely available without asking, so not (yet) OKD compliant "
+    },
+    "sparql": [],
+    "full_download": [],
+    "website": "http://viaf.org/viaf/data/",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "OCLC Online Computer Library Center, Inc.",
+      "email": "oclc@oclc.org"
+    },
+    "owner": {
+      "name": "",
+      "email": ""
+    },
+    "keywords": [
+      "bibliographic",
+      "format-owl",
+      "format-rdf",
+      "format-skos",
+      "library",
+      "lld",
+      "lod",
+      "lodcloud-diagram-2011-09-19",
+      "lodcloud-diagram-2014-08-30",
+      "no-deref-vocab",
+      "no-license-metadata",
+      "no-provenance-metadata",
+      "no-vocab-mappings",
+      "publications",
+      "published-by-producer",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "newKeyword": "",
+    "Image": "",
+    "example": [
+      {
+        "title": "",
+        "access_url": "http://viaf.org/viaf/40280446/",
+        "description": "Example (RDF/XML)"
+      },
+      {
+        "title": "",
+        "access_url": "http://viaf.org/viaf/86518157",
+        "description": "Example (RDF/XML)"
+      }
+    ],
+    "other_download": [
+      {
+        "title": "VIAF Links (txt)",
+        "access_url": "http://viaf.org/viaf/data/viaf-20130615-links.txt.gz",
+        "description": "This is a text file showing the correspondence between source IDs in clusters, including external links such as Wikipedia\r\n"
+      },
+      {
+        "title": "VIAF Clusters (XML)",
+        "access_url": "http://viaf.org/viaf/data/viaf-20130615-clusters.xml.gz",
+        "description": "This file contains one 'native' XML record per line for each VIAF cluster\r\n"
+      },
+      {
+        "title": "VIAF Clusters (RDF)",
+        "access_url": "http://viaf.org/viaf/data/viaf-20130615-clusters-rdf.xml.gz",
+        "description": "This file contains one RDF record per line for each VIAF cluster\r\n"
+      },
+      {
+        "title": "VIAF Clusters (MARC 21)",
+        "access_url": "http://viaf.org/viaf/data/viaf-20130615-clusters-marc21.xml.gz",
+        "description": "This file contains one MARC-21 XML record per line for each VIAF cluster\r\n"
+      },
+      {
+        "title": "VIAF clusters (MARC 21 - ISO-2709)",
+        "access_url": "http://viaf.org/viaf/data/viaf-20130615-clusters-marc21.iso.gz",
+        "description": "This file contains one ISO-2709 MARC-21 record per line for each VIAF cluster\r\n"
+      },
+      {
+        "title": "VIAF redirections (RDF)",
+        "access_url": "http://viaf.org/viaf/data/viaf-20130615-persist-rdf.xml.gz",
+        "description": "This file shows redirections within the VIAF dataset (in RDF)\r\n"
+      }
+    ],
+    "namespace": "http://viaf.org/viaf/",
+    "links": [
+      {
+        "target": "dbpedia",
+        "value": "10000"
+      },
+      {
+        "target": "dnb-gemeinsame-normdatei",
+        "value": "4000000"
+      }
+    ],
+    "time": "",
+    "triples": "200000000",
+    "category": "ch-tangible",
+    "image": ""
+  }
+}


### PR DESCRIPTION
This PR is a request to update the metadata of the following resource in the CHeCLOUD.

**Identifier**: ASCDC-DQOT
**Title**: Database of Qing Official Titles (DQOT) test eteste
**Description**: TESTES----Thfdsfdsfdse LOD dataset of ASCDC_Database of Qing Official Titles (DQOT) was created by the Academia Sinica Center for Digital Cultures (ASCDC) and based on the metadata from the online “Database of Qing Official Titles” (清代職官資料庫, https://newarchive.ihp.sinica.edu.tw/officerc/officerkm2?@@0.21081762485249556), which was established and maintained by the Institute of History and Philology, Academia Sinica, Taipei, Taiwan (ROC). The data includes titles of the official positions in the Qing dynasty (1644-1911) and their detailed information, which can serve as authority files or controlled vocabularies for official positions in the study of Chinese history. Containing 6,846 data records and 164,733 triples, the textual content within the LOD dataset is licensed under the Creative Commons Attribution (CC BY).
**LLM Topic**: Cultural Heritage - Generic