### PR TITLE
Update metadata request: Rijksmuseum

### DIFF
--- a/monitoring_requests/Rijksmuseum.json
+++ b/monitoring_requests/Rijksmuseum.json
@@ -10,7 +10,7 @@
     },
     "sparql": [
       {
-        "access_url": "https://data.netwerkdigitaalerfgoed.nl/Rijksmuseum/exhibitions/sparql",
+        "access_url": "https://api.data.netwerkdigitaalerfgoed.nl/datasets/Rijksmuseum/exhibitions/sparql",
         "title": "",
         "description": "SPARQL endpoint"
       }


### PR DESCRIPTION
This PR is a request to update the metadata of the following resource in the CHeCLOUD.

**Identifier**: Rijksmuseum
**Title**: Rijksmuseum Collection
**Description**: The Rijksmuseum Collection dataset is an open-access digital repository of artworks and historical artifacts housed in the Rijksmuseum, the national museum of the Netherlands. The dataset provides structured metadata and high-resolution images of thousands of artworks, including paintings, sculptures, prints, ceramics, and historical objects.
**LLM Topic**: Cultural Heritage - Tangible