### PR TITLE
Update metadata request: dnb-gemeinsame-normdatei

### DIFF
--- a/monitoring_requests/dnb-gemeinsame-normdatei.json
+++ b/monitoring_requests/dnb-gemeinsame-normdatei.json
@@ -1,0 +1,209 @@
+{
+  "dnb-gemeinsame-normdatei": {
+    "_id": "dnb-gemeinsame-normdatei0000018da796a714",
+    "identifier": "dnb-gemeinsame-normdatei",
+    "title": "Gemeinsame Normdatei (GND)",
+    "doi": "",
+    "license": "http://www.opendefinition.org/licenses/cc-zero",
+    "description": {
+      "en": "GND stands for \"Gemeinsame Normdatei\" (Integrated Authority File) and offers a broad range of elements to describe authorities. The GND originates from the German library community and aims to solve the name ambiguity problem in the library world. Corresponding data is usually expressed in a customized MARC 21 Authority Format (GND MARC Format) which is quite domain specific and is not used beyond the library and publisher world. The GND ontology tries to bridge this gap by providing a format specification for the usage in the semantic web.\n\nThe need for name disambiguity and entries having an authoritative character is an issue that concerns a lot more communities than the library world. In a growing information society the unique identification and linking of persons, places and other authorities becomes more and more important. The GND Ontology aims to transfer the made experience from libraries to the web community by providing a vocabulary for the description of differentiated and undifferentiated persons, conferences or events, corporate bodies, places or geographic names, subject headings, and works.\n\nTo ensure compatibility aspects the GND ontology aligns a number of already established vocabularies like the FOAF vocabulary.\n\nThe GND is a young specification that probably will underlie certain smaller changes. However, the currently defined classes and properties have a status of stability. But we also expect the introduction of additional elements caused by newly upcoming requirements within the community. From January 2014 on, the Linked Data Service of the German National Library (DNB) will issue scheduled releases and will be integrated in the export releases of the other formats. Changes to the conversion and to the data modelling will be made in January, May and September. Changes will be notified in advance via the Linked Data Service mailing list (http://lists.dnb.de/mailman/listinfo/lds) and the Integrated\nAuthority File GND Ontology mailing list (http://lists.dnb.de/mailman/listinfo/gnd-ontology). Please subscribe if you are interested in receiving information about future developments in DNB Linked Data Services.\nIn a schedule corresponding to the export releases, updated dumps of the authority and bibliographic data in RDF/XML and Turtle will be available for download in February, June and October.\n\nThe authors welcome comments on this document, preferably via the public GND ontology list; public archives are available. \n\nThe Integrated Authority File\n\nThe \"Gemeinsame Normdatei\" (GND, Integrated Authority File) brings together the content of the former Corporate Body Authority File GKD (Gemeinsame Körperschaftsdatei), the Name Authority File PND (Personennamendatei), the Subject Headings Authority File SWD (Schlagwortnormdatei) and the Uniform Title File of the Deutsches Musikarchiv EST file (Einheitssachtitel-Datei ) to form an integrated authority file.\n\nThe target has therefore been reached of setting up an authority file which covers all types of entities and which serves as a common, authoritative reference system for libraries' bibliographic data and for the cataloging data of other authority file users such as archives, museums, projects, scientific and cultural institutions. All library networks in the German-speaking countries and the German Union Catalogue of Serials (ZDB) are involved in the GND project alongside the German National Library.\n\nThe GND should consign to the past problems arising from different formats, parallel storage of data records and different rules for descriptive and subject cataloging.\n\nThe objective of the GND is to form a modern, web-compatible authority file which is capable of networking the wide range of resources and information held by libraries and other cultural institutions in the German-speaking countries and making these accessible to users. To approach a web-compatible authority file we also provide the GND as linked data. Therefore we developed an independent GND specific vocabulary (GND Ontology) that almost completely covers the offered GND concepts provided in MARC 21. "
+    },
+    "sparql": [
+      {
+        "access_url": "",
+        "title": "",
+        "description": ""
+      }
+    ],
+    "full_download": [
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File) ",
+        "download_url": "https://data.dnb.de/opendata/authorities-gnd_lds.nt.gz",
+        "description": "nTriples"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File) ",
+        "download_url": "https://data.dnb.de/opendata/authorities-gnd_lds.hdt.gz",
+        "description": "HDT"
+      }
+    ],
+    "website": "https://www.dnb.de/lds",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "Deutsche Nationalbibliothek and German Library Networks",
+      "email": "metadatendienste@dnb.de"
+    },
+    "owner": {
+      "name": "",
+      "email": "tracy.hoffmann@gmail.com"
+    },
+    "keywords": [
+      "authorities",
+      "bibliographic",
+      "buildings",
+      "concepts",
+      "corporations",
+      "crossdomain",
+      "format-foaf",
+      "format-rdf",
+      "format-rdfs",
+      "format-skos",
+      "germany",
+      "lld",
+      "lod",
+      "no-deref-vocab",
+      "no-license-metadata",
+      "no-provenance-metadata",
+      "no-vocab-mappings",
+      "persons",
+      "places",
+      "published-by-producer",
+      "rdf",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "Image": "",
+    "example": [
+      {
+        "title": "Example Person",
+        "access_url": "https://d-nb.info/gnd/118514768/about/lds",
+        "description": "Example (Turtle)"
+      },
+      {
+        "title": "Example Subject Heading",
+        "access_url": "https://d-nb.info/gnd/4190055-8/about/lds",
+        "description": "Example (Turtle)"
+      },
+      {
+        "title": "Example Corporate Body",
+        "access_url": "https://d-nb.info/gnd/10140798-1/about/lds",
+        "description": "Example (Turtle)"
+      },
+      {
+        "title": "Example Person",
+        "access_url": "https://d-nb.info/gnd/11850553X/about/lds",
+        "description": "Example (Turtle)"
+      }
+    ],
+    "other_download": [
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Geographical entity",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-geografikum_lds.jsonld.gz",
+        "description": "JSONLD"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Geographical entity",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-geografikum_lds.rdf.gz",
+        "description": "RDF/XML"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Geographical entity",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-geografikum_lds.ttl.gz",
+        "description": "Turtle"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  -  Corporate body",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-koerperschaft_lds.jsonld.gz",
+        "description": "JSONLD"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  -  Corporate body",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-koerperschaft_lds.rdf.gz",
+        "description": "RDF/XML"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  -  Corporate body",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-koerperschaft_lds.ttl.gz",
+        "description": "Turtle"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  -  Congress",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-kongress_lds.jsonld.gz",
+        "description": "JSONLD"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  -  Congress",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-kongress_lds.rdf.gz",
+        "description": "RDF/XML"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  -  Congress",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-kongress_lds.turtle.gz",
+        "description": "Turtle"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Person",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-person_lds.jsonld.gz",
+        "description": "JSONLD"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Person",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-person_lds.rdf.gz",
+        "description": "RDF/XML"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Person",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-person_lds.ttl.gz",
+        "description": "Turtle"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Subject term",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-sachbegriff_lds.jsonld.gz",
+        "description": "JSONLD"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Subject term",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-sachbegriff_lds.rdf.gz",
+        "description": "RDF/XML"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Subject term",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-sachbegriff_lds.ttl.gz",
+        "description": "Turtle"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Work",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-werk_lds.jsonld.gz",
+        "description": "JSONLD"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Work",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-werk_lds.rdf.gz",
+        "description": "RDF/XML"
+      },
+      {
+        "title": "Gemeinsame Normdatei (Integrated Authority File)  - Work",
+        "access_url": "https://data.dnb.de/opendata/authorities-gnd-werk_lds.ttl.gz",
+        "description": "Turtle"
+      }
+    ],
+    "namespace": "https://d-nb.info/gnd/",
+    "links": [
+      {
+        "target": "dbpedia",
+        "value": "80315"
+      },
+      {
+        "target": "stw-thesaurus-for-economics",
+        "value": "16628"
+      },
+      {
+        "target": "viaf",
+        "value": "9317888"
+      },
+      {
+        "target": "geonames-semantic-web",
+        "value": "63754"
+      },
+      {
+        "target": "wikidata",
+        "value": "1785108"
+      }
+    ],
+    "time": "0000018da796a714",
+    "triples": "165639860",
+    "category": "ch-tangible",
+    "image": "",
+    "newKeyword": ""
+  }
+}

--- a/monitoring_requests/dnb-gemeinsame-normdatei.json
+++ b/monitoring_requests/dnb-gemeinsame-normdatei.json
@@ -10,8 +10,8 @@
     },
     "sparql": [
       {
-        "access_url": "",
-        "title": "",
+        "access_url": "https://sparql.dnb.de/",
+        "title": "SPARQL Endpoint",
         "description": ""
       }
     ],

--- a/monitoring_requests/roceeh-road.json
+++ b/monitoring_requests/roceeh-road.json
@@ -1,0 +1,70 @@
+{
+  "roceeh-road": {
+    "_id": "roceeh-road0000018fe7952923",
+    "identifier": "roceeh-road",
+    "title": "ROCEEH Out of Africa Database (ROAD)",
+    "doi": "",
+    "license": "http://www.opendefinition.org/licenses/cc-by-sa",
+    "description": {
+      "en": "Database on human origins in Africa and Eurasia between 3,000,000 and 20,000 years ago covering prehistoric archaeology, paleoanthropology, paleoenvironment and geography."
+    },
+    "sparql": [
+      {
+        "access_url": "http://www.roceeh.uni-tuebingen.de:3030/road/sparql",
+        "title": "SPARQL Endpoint",
+        "description": ""
+      }
+    ],
+    "full_download": [],
+    "website": "https://www.roceeh.uni-tuebingen.de/roadweb/smarty_road_simple_search.php",
+    "domain": "cultural-heritage",
+    "contact_point": {
+      "name": "Christian Sommer",
+      "email": "christian.sommer@uni-tuebingen.de"
+    },
+    "owner": {
+      "name": "",
+      "email": "csommer.geo@gmail.com"
+    },
+    "keywords": [
+      "Archaeology",
+      "Paleoanthropology",
+      "Paleoenvironment",
+      "Paleontology",
+      "Palynology",
+      "Prehistory",
+      "Geography",
+      "cultural-heritage",
+      "ch-tangible"
+    ],
+    "Image": "",
+    "example": [],
+    "other_download": [
+      {
+        "title": "RDF Dump",
+        "access_url": "https://github.com/sommergeo/roceeh2wiki?tab=readme-ov-file",
+        "description": "RDF dump manually discovered"
+      }
+    ],
+    "namespace": "",
+    "links": [
+      {
+        "target": "periodo",
+        "value": "1"
+      },
+      {
+        "target": "dbpedia",
+        "value": "1"
+      },
+      {
+        "target": "w3c",
+        "value": "1"
+      }
+    ],
+    "time": "0000018fe7952923",
+    "triples": "4000000",
+    "category": "ch-tangible",
+    "image": "https://www.hadw-bw.de/sites/default/files/styles/teaser_image_1x_largescreen/public/media/Roceeh.jpg?h=d92b20e8&itok=gKBbZXNA",
+    "newKeyword": ""
+  }
+}


### PR DESCRIPTION
This PR is a request to update the metadata of the following resource in the CHeCLOUD.

**Identifier**: dnb-gemeinsame-normdatei
**Title**: Gemeinsame Normdatei (GND)
**Description**: GND stands for "Gemeinsame Normdatei" (Integrated Authority File) and offers a broad range of elements to describe authorities. The GND originates from the German library community and aims to solve the name ambiguity problem in the library world. Corresponding data is usually expressed in a customized MARC 21 Authority Format (GND MARC Format) which is quite domain specific and is not used beyond the library and publisher world. The GND ontology tries to bridge this gap by providing a format specification for the usage in the semantic web.

The need for name disambiguity and entries having an authoritative character is an issue that concerns a lot more communities than the library world. In a growing information society the unique identification and linking of persons, places and other authorities becomes more and more important. The GND Ontology aims to transfer the made experience from libraries to the web community by providing a vocabulary for the description of differentiated and undifferentiated persons, conferences or events, corporate bodies, places or geographic names, subject headings, and works.

To ensure compatibility aspects the GND ontology aligns a number of already established vocabularies like the FOAF vocabulary.

The GND is a young specification that probably will underlie certain smaller changes. However, the currently defined classes and properties have a status of stability. But we also expect the introduction of additional elements caused by newly upcoming requirements within the community. From January 2014 on, the Linked Data Service of the German National Library (DNB) will issue scheduled releases and will be integrated in the export releases of the other formats. Changes to the conversion and to the data modelling will be made in January, May and September. Changes will be notified in advance via the Linked Data Service mailing list (http://lists.dnb.de/mailman/listinfo/lds) and the Integrated
Authority File GND Ontology mailing list (http://lists.dnb.de/mailman/listinfo/gnd-ontology). Please subscribe if you are interested in receiving information about future developments in DNB Linked Data Services.
In a schedule corresponding to the export releases, updated dumps of the authority and bibliographic data in RDF/XML and Turtle will be available for download in February, June and October.

The authors welcome comments on this document, preferably via the public GND ontology list; public archives are available. 

The Integrated Authority File

The "Gemeinsame Normdatei" (GND, Integrated Authority File) brings together the content of the former Corporate Body Authority File GKD (Gemeinsame Körperschaftsdatei), the Name Authority File PND (Personennamendatei), the Subject Headings Authority File SWD (Schlagwortnormdatei) and the Uniform Title File of the Deutsches Musikarchiv EST file (Einheitssachtitel-Datei ) to form an integrated authority file.

The target has therefore been reached of setting up an authority file which covers all types of entities and which serves as a common, authoritative reference system for libraries' bibliographic data and for the cataloging data of other authority file users such as archives, museums, projects, scientific and cultural institutions. All library networks in the German-speaking countries and the German Union Catalogue of Serials (ZDB) are involved in the GND project alongside the German National Library.

The GND should consign to the past problems arising from different formats, parallel storage of data records and different rules for descriptive and subject cataloging.

The objective of the GND is to form a modern, web-compatible authority file which is capable of networking the wide range of resources and information held by libraries and other cultural institutions in the German-speaking countries and making these accessible to users. To approach a web-compatible authority file we also provide the GND as linked data. Therefore we developed an independent GND specific vocabulary (GND Ontology) that almost completely covers the offered GND concepts provided in MARC 21. 
**LLM Topic**: Not classified